### PR TITLE
Add missing required apiVersion field in Chart.yaml

### DIFF
--- a/deploy/helm/kube-fencing/Chart.yaml
+++ b/deploy/helm/kube-fencing/Chart.yaml
@@ -1,3 +1,4 @@
+apiVersion: v2
 name: kube-fencing
 description: Fencing implementation for Kubernetes
 version: 2.2.0


### PR DESCRIPTION
The `apiVersion` field is required in `Chart.yaml` as per [Helm documentation](https://helm.sh/docs/topics/charts/#the-chartyaml-file). Since it's currently missing, this Helm chart fails validation of some tools.