### PR TITLE
Use sum32 hash if any job name goes beyond 63 char

### DIFF
--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -312,9 +312,21 @@ func newJobForJob(job *batchv1.Job, podTemplate *v1.PodTemplate) *batchv1.Job {
 
 	// Creating new Job
 	tr := true
+	jobName := job.Name + "-" + suffix
+	if len(jobName) > 63 {
+		jobHash := util.GetHash(job.Name)
+		newSuffix := jobHash + "-" + suffix
+
+		//If it is still going beyond 63 char, trim suffix
+		if len(newSuffix) > 63 {
+			newSuffix = newSuffix[:63]
+		}
+		jobName = job.Name[:(63-len(newSuffix))] + newSuffix
+	}
+
 	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        job.Name + "-" + suffix,
+			Name:        jobName,
 			Namespace:   job.Namespace,
 			Labels:      labels,
 			Annotations: annotations,

--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -394,9 +394,23 @@ func newJobForNode(node *v1.Node, podTemplate *v1.PodTemplate) *batchv1.Job {
 
 	// Creating new Job
 	tr := true
+	jobName := prefix + "-" + node.Name
+
+	//Use hash of nodename if orignal job name is going beyond 63 char
+	if len(jobName) > 63 {
+		nodeHash := util.GetHash(node.Name)
+		jobName = prefix + "-" + nodeHash
+
+		//If it is still going beyond 63 char, trim prefix
+		if len(jobName) > 63 {
+			rem := 63 - len(nodeHash) - 1
+			jobName = prefix[:rem] + "-" + nodeHash
+		}
+	}
+
 	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        prefix + "-" + node.Name,
+			Name:        jobName,
 			Namespace:   Namespace,
 			Labels:      labels,
 			Annotations: annotations,

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1,6 +1,9 @@
 package util
 
 import (
+	"fmt"
+	"hash/fnv"
+
 	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 )
@@ -31,4 +34,11 @@ func GetJobCondition(status *batchv1.JobStatus, conditionType batchv1.JobConditi
 		}
 	}
 	return -1, nil
+}
+
+// GetHash returns fixed size hash of given string
+func GetHash(name string) string {
+	algo := fnv.New32()
+	algo.Write([]byte(name))
+	return fmt.Sprint(algo.Sum32())
 }


### PR DESCRIPTION
Hash used - sum32

- For fencing job if use of node name exceeds the job name length beyond 63 char, use hash of the node name. If it is still going beyond 63, trim the prefix provided by user

- For fencing afterhook job name is exceeding 63 char, replace end of fencing job name with its hash. If it is still going beyond 63, trim the suffix provided by user.


Test 1 - Normal scenario where job names are bellow 63 char
NAME                                                            COMPLETIONS   DURATION   AGE
job.batch/fence-r7515-057-vm74.cloudapp.azure.com-after-hook   1/1           3s         5s
job.batch/fence-r7515-057-vm74.cloudapp.azure.com              1/1           31s        36s

 
Test 2 - user given pod.Name "testclust-fencing-38991" for fencing which was exceeding name limit only for afterhook
NAME                                                                        COMPLETIONS   DURATION   AGE
job.batch/testclust-fencing-38991-r7515-057-vm74.clo2248817392-after-hook   1/1           4s         4s
job.batch/testclust-fencing-38991-r7515-057-vm74.cloudapp.azure.com         1/1           28s        32s

Test 3 - user given pod.Name "testclust-fencing-38991-abcdefghijklmnopqrstuvwxyz" for fencing which was exceeding name limit for fencing with node name
NAME                                                                        COMPLETIONS   DURATION   AGE
job.batch/testclust-fencing-38991-abcdefghijklmnopqrs730193491-after-hook   1/1           3s         11s
job.batch/testclust-fencing-38991-abcdefghijklmnopqrstuvwxyz-1107273493     1/1           29s        40s

Test 4 - user given pod.Name "abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz" for afterhook which exceeds 63 char limit with fencing jobname appened
NAME                                                                        COMPLETIONS   DURATION   AGE
job.batch/730193491-abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz   1/1           3s         6s
job.batch/testclust-fencing-38991-abcdefghijklmnopqrstuvwxyz-1107273493     1/1           29s        35s

 
