### PR TITLE
Add commonLabels to be applied to all created resources

### DIFF
--- a/deploy/helm/kube-fencing/templates/controller-deployment.yaml
+++ b/deploy/helm/kube-fencing/templates/controller-deployment.yaml
@@ -3,6 +3,8 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  labels:
+    {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   name: {{ template "fencing.fullname" . }}-controller
 spec:
   replicas: {{ .Values.controller.replicas }}
@@ -12,7 +14,8 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "fencing.fullname" . }}-controller
+        app: {{ template "fencing.fullname" . }}-controller          
+        {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 8 }}{{- end }}
     spec:
       {{- with .Values.controller.nodeSelector }}
       nodeSelector:

--- a/deploy/helm/kube-fencing/templates/controller-rbac.yaml
+++ b/deploy/helm/kube-fencing/templates/controller-rbac.yaml
@@ -3,11 +3,15 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  labels:
+    {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   name: {{ template "fencing.fullname" . }}-controller
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
+  labels:
+    {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   name: {{ template "fencing.fullname" . }}-controller
 rules:
   - apiGroups: ["batch", "extensions"]
@@ -32,6 +36,8 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
+  labels:
+    {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   name: {{ template "fencing.fullname" . }}-controller
 subjects:
   - kind: ServiceAccount
@@ -45,6 +51,8 @@ roleRef:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
+  labels:
+    {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   name: {{ template "fencing.fullname" . }}-controller
 rules:
   - apiGroups: [""]
@@ -66,6 +74,8 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
+  labels:
+    {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   name: {{ template "fencing.fullname" . }}-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/deploy/helm/kube-fencing/templates/podsecuritypolicy.yaml
+++ b/deploy/helm/kube-fencing/templates/podsecuritypolicy.yaml
@@ -2,6 +2,8 @@
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
+  labels:
+    {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   name: {{ template "fencing.fullname" . }}
   annotations:
     seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'

--- a/deploy/helm/kube-fencing/templates/switcher-daemonset.yaml
+++ b/deploy/helm/kube-fencing/templates/switcher-daemonset.yaml
@@ -3,6 +3,8 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
+  labels:
+    {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   name: {{ template "fencing.fullname" . }}-switcher
 spec:
   selector:
@@ -12,6 +14,7 @@ spec:
     metadata:
       labels:
         app: {{ template "fencing.fullname" . }}-switcher
+        {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 8 }}{{- end }}
     spec:
       {{- with .Values.switcher.nodeSelector }}
       nodeSelector:

--- a/deploy/helm/kube-fencing/templates/switcher-rbac.yaml
+++ b/deploy/helm/kube-fencing/templates/switcher-rbac.yaml
@@ -3,11 +3,15 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  labels:
+    {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   name: {{ template "fencing.fullname" . }}-switcher
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
+  labels:
+    {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   name: {{ template "fencing.fullname" . }}-switcher
 rules:
   - apiGroups: [""]
@@ -17,6 +21,8 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
+  labels:
+    {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   name: {{ template "fencing.fullname" . }}-switcher
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31,6 +37,8 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  labels:
+    {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   name: {{ template "fencing.fullname" . }}-switcher
 rules:
   - apiGroups: ["extensions"]
@@ -41,6 +49,8 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
+  labels:
+    {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   name: {{ template "fencing.fullname" . }}-switcher
 roleRef:
   kind: Role

--- a/deploy/helm/kube-fencing/values.yaml
+++ b/deploy/helm/kube-fencing/values.yaml
@@ -1,3 +1,5 @@
+# Labels to apply to all resources
+commonLabels: {}
 # ------------------------------------------------------------------------------
 # fencing-controller watches for the failed nodes and initializates fencing
 # process


### PR DESCRIPTION
Application of commonLabels to all resources created by the chart. 
The addition of commonLabels provides consistency and aids in better resource management by applying specific labels uniformly across all resources.

**Changes Made:**

- Implemented support for commonLabels in the Helm chart.
- Updated templates to include the commonLabels field for all resources generated by the chart.

**Compatibility Considerations:**

- These changes do not impact existing deployments that do not specify commonLabels.
- Users can opt to utilize commonLabels for their specific requirements without affecting the chart's backward compatibility.