### PR TITLE
Upgrade fencing to go 1.24 and kubernetes api to 0.32.3

### DIFF
--- a/build/controller/Dockerfile
+++ b/build/controller/Dockerfile
@@ -1,7 +1,7 @@
 ############################
 # STEP 1 build executable binary
 ############################
-FROM golang:1.18-alpine3.15 AS builder
+FROM golang:1.24-alpine AS builder
 
 # Install git.
 # Git is required for fetching the dependencies.
@@ -13,7 +13,7 @@ WORKDIR $GOPATH/src/github.com/kvaps/kube-fencing/cmd/controller
 # Fetch dependencies.
 
 # Using go get.
-RUN go get -d -v
+RUN go mod tidy
 # Build the binary.
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -ldflags="-w -s" -o /go/bin/fencing-controller
 

--- a/build/switcher/Dockerfile
+++ b/build/switcher/Dockerfile
@@ -1,7 +1,7 @@
 ############################
 # STEP 1 build executable binary
 ############################
-FROM golang:1.18-alpine3.15 AS builder
+FROM golang:1.24-alpine AS builder
 
 # Install git.
 # Git is required for fetching the dependencies.
@@ -13,7 +13,7 @@ WORKDIR $GOPATH/src/github.com/kvaps/kube-fencing/cmd/switcher
 # Fetch dependencies.
 
 # Using go get.
-RUN go get -d -v
+RUN go mod tidy
 # Build the binary.
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -ldflags="-w -s" -o /go/bin/fencing-switcher
 

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -54,8 +54,6 @@ func main() {
 
 	// Create a new Cmd to provide shared dependencies and start components
 	mgr, err := manager.New(cfg, manager.Options{
-		MetricsBindAddress:      "0",
-		Namespace:               Namespace,
 		LeaderElection:          true,
 		LeaderElectionID:        "kube-fencing-lock",
 		LeaderElectionNamespace: Namespace,

--- a/go.mod
+++ b/go.mod
@@ -1,40 +1,40 @@
 module github.com/kvaps/kube-fencing
 
-go 1.13
+go 1.24.0
 
 require (
-	k8s.io/api v0.25.2
-	k8s.io/apimachinery v0.25.2
-	k8s.io/client-go v0.25.2
+	k8s.io/api v0.32.3
+	k8s.io/apimachinery v0.32.3
+	k8s.io/client-go v1.5.2
 	k8s.io/klog v1.0.0
-	k8s.io/kubernetes v1.25.3
-	sigs.k8s.io/controller-runtime v0.13.0
+	k8s.io/kubernetes v1.32.3
+	sigs.k8s.io/controller-runtime v0.20.4
 )
 
 replace (
-	k8s.io/api => k8s.io/api v0.25.2
-	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.25.2
-	k8s.io/apimachinery => k8s.io/apimachinery v0.25.2
-	k8s.io/apiserver => k8s.io/apiserver v0.25.2
-	k8s.io/cli-runtime => k8s.io/cli-runtime v0.25.2
-	k8s.io/client-go => k8s.io/client-go v0.25.2
-	k8s.io/cloud-provider => k8s.io/cloud-provider v0.25.2
-	k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.25.2
-	k8s.io/code-generator => k8s.io/code-generator v0.25.2
-	k8s.io/component-base => k8s.io/component-base v0.25.2
-	k8s.io/component-helpers => k8s.io/component-helpers v0.25.2
-	k8s.io/controller-manager => k8s.io/controller-manager v0.25.2
-	k8s.io/cri-api => k8s.io/cri-api v0.25.2
-	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.25.2
-	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.25.2
-	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.25.2
-	k8s.io/kube-proxy => k8s.io/kube-proxy v0.25.2
-	k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.25.2
-	k8s.io/kubectl => k8s.io/kubectl v0.25.2
-	k8s.io/kubelet => k8s.io/kubelet v0.25.2
-	k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.25.2
-	k8s.io/metrics => k8s.io/metrics v0.25.2
-	k8s.io/mount-utils => k8s.io/mount-utils v0.25.2
-	k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.25.2
-	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.25.2
+	k8s.io/api => k8s.io/api v0.32.3
+	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.32.3
+	k8s.io/apimachinery => k8s.io/apimachinery v0.32.3
+	k8s.io/apiserver => k8s.io/apiserver v0.32.3
+	k8s.io/cli-runtime => k8s.io/cli-runtime v0.32.3
+	k8s.io/client-go => k8s.io/client-go v0.32.3
+	k8s.io/cloud-provider => k8s.io/cloud-provider v0.32.3
+	k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.32.3
+	k8s.io/code-generator => k8s.io/code-generator v0.32.3
+	k8s.io/component-base => k8s.io/component-base v0.32.3
+	k8s.io/component-helpers => k8s.io/component-helpers v0.32.3
+	k8s.io/controller-manager => k8s.io/controller-manager v0.32.3
+	k8s.io/cri-api => k8s.io/cri-api v0.32.3
+	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.32.3
+	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.32.3
+	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.32.3
+	k8s.io/kube-proxy => k8s.io/kube-proxy v0.32.3
+	k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.32.3
+	k8s.io/kubectl => k8s.io/kubectl v0.32.3
+	k8s.io/kubelet => k8s.io/kubelet v0.32.3
+	k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.32.3
+	k8s.io/metrics => k8s.io/metrics v0.32.3
+	k8s.io/mount-utils => k8s.io/mount-utils v0.32.3
+	k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.32.3
+	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.32.3
 )

--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -42,7 +42,9 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	}
 
 	// Watch for changes to primary resource Job
-	err = c.Watch(&source.Kind{Type: &batchv1.Job{}}, &handler.EnqueueRequestForObject{})
+	err = c.Watch(
+		source.Kind(mgr.GetCache(), &batchv1.Job{}, &handler.TypedEnqueueRequestForObject[*batchv1.Job]{}),
+	)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -47,7 +47,9 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	}
 
 	// Watch for changes to primary resource Node
-	err = c.Watch(&source.Kind{Type: &v1.Node{}}, &handler.EnqueueRequestForObject{})
+	err = c.Watch(
+		source.Kind(mgr.GetCache(), &v1.Node{}, &handler.TypedEnqueueRequestForObject[*v1.Node]{}),
+	)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The fencing images are based on old versions of go and old kubernetes api, so they contain a lot of CVEs. So I'm making this Pull request to increase the versions in order to remove as many CVEs as possible

With regard to the c.watch function, I have followed the runtime controller documentation: 
https://github.com/kubernetes-sigs/controller-runtime/blob/main/pkg/handler/example_test.go

And for the options manager, the doc announces that the two fields are deleted, by default the manager looks in all namespaces 
